### PR TITLE
Remove unused configuration flags

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -16,9 +16,4 @@ func init() {
 	viper.BindPFlag("limit", listCmd.PersistentFlags().Lookup("limit"))
 
 	rootCmd.AddCommand(listCmd)
-
-	var from string
-	var to string
-	listCmd.PersistentFlags().StringVar(&from, "from", "", "filter results from this date (dd/mm/yyyy)")
-	listCmd.PersistentFlags().StringVar(&to, "to", "", "filter results to this date (dd/mm/yyyy)")
 }


### PR DESCRIPTION
Fixes #3 by removing unused configuration flags from the list command.